### PR TITLE
Remove macOS-10.13 from the test list

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -49,7 +49,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-10.13, macos-11, macos-12, macos-13]
+        os: [macos-11, macos-12, macos-13]
         arch: [amd64, arm64]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
According the list of available OS images on GitHub the oldest macOS version available is now 11: https://github.com/actions/runner-images

I've removed macos-10.13 from the matrix since it doesn't allow the action to complete.